### PR TITLE
Fix 13 missing dependencies in Makefile.in reported by Vemake

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -10,7 +10,7 @@ DESTDIR=
 DIRPAX=@DIRPAX@
 PAX=@PAX@
 
-HEADERS=bftpdutmp.h commands.h commands_admin.h cwd.h dirlist.h list.h login.h logging.h main.h mystring.h options.h targzip.h mypaths.h md5.h md5_loc.h
+HEADERS=bftpdutmp.h commands.h commands_admin.h cwd.h dirlist.h list.h login.h logging.h main.h mystring.h options.h targzip.h mypaths.h md5.h md5_loc.h config.h
 OBJS=bftpdutmp.o commands.o commands_admin.o cwd.o dirlist.o list.o login.o logging.o main.o mystring.o options.o md5.o
 SRCS=bftpdutmp.c commands.c commands_admin.c cwd.c dirlist.c list.c login.c logging.c main.c mystring.c options.c md5.c
 
@@ -22,7 +22,7 @@ bftpd: $(OBJS)
 	./mksources $(DIRPAX)
 	$(CC) $(OBJS2LINK) $(LDFLAGS) $(LIBS) -o bftpd
 
-$(OBJS): $(HEADERS) Makefile
+$(OBJS): $(HEADERS) Makefile $(SRCS)
 
 install: all
 	mkdir -p $(DESTDIR)/$(prefix)/sbin
@@ -42,7 +42,7 @@ clean distclean:
 	rm -f *~ $(OBJS) bftpd mksources.finished config.cache
 	[ "$(DIRPAX)" = "" ] || make -C $(DIRPAX) clean
 
-newversion: clean
+newversion: clean Makefile.in
 	cat Makefile.in | sed -e s/$(VERSION)/$(NEWVERSION)/g > Makefile.foo
 	mv Makefile.foo Makefile.in
 	./configure --enable-pax=pax --enable-libz --enable-pam


### PR DESCRIPTION
Hi, I've fixed 13 dependencies missing reported.
Those issues can cause incorrect results when bftpd is incrementally built.

For example, any changes in "config.h" and "main.c" will not cause "main.o" to be rebuilt, which is incorrect.

I've tested it on my computer, the fixed version worked as expected.

Thanks
Vemake